### PR TITLE
Fix performance issues on status page

### DIFF
--- a/src/electronApp/angularApp/components/status/status.component.css
+++ b/src/electronApp/angularApp/components/status/status.component.css
@@ -6,9 +6,11 @@
 .statusTable th {
     text-align: right;
     padding: 5px;
+    width: 50%;
 }
 
 .statusTable td {
     text-align: left;
     padding: 5px;
+    width: 50%;
 }

--- a/src/electronApp/angularApp/components/status/status.component.html
+++ b/src/electronApp/angularApp/components/status/status.component.html
@@ -42,14 +42,18 @@
     <tr>
         <th>Camera</th>
 
-        <div *ngIf="CameraAvailable; then cameraAvailableBlock else cameraNotAvailableBlock"></div>
-        <ng-template #cameraAvailableBlock>
-            <td><a [routerLink]="'/camera'">View feed</a></td>
-        </ng-template>
-
-        <ng-template #cameraNotAvailableBlock>
-            <td>Not Available (<a class="accentColor" target="_blank" href='https://github.com/andycb/AdventurerClientJS/wiki/Using-The-Printer-Camera'>Help</a>)</td>
-        </ng-template>
+        <td>
+            <div *ngIf="CameraStateLoaded">
+                <div *ngIf="CameraAvailable; then cameraAvailableBlock else cameraNotAvailableBlock"></div>
+                <ng-template #cameraAvailableBlock>
+                    <a class="accentColor" [routerLink]="'/camera'">View feed</a>
+                </ng-template>
+        
+                <ng-template #cameraNotAvailableBlock>
+                    Not Available (<a class="accentColor" target="_blank" href='https://github.com/andycb/AdventurerClientJS/wiki/Using-The-Printer-Camera'>Help</a>)
+                </ng-template>
+            </div>
+        </td>
     </tr>
 
     <tr>

--- a/src/electronApp/angularApp/components/status/status.component.ts
+++ b/src/electronApp/angularApp/components/status/status.component.ts
@@ -57,6 +57,16 @@ export class StatusComponent implements OnInit {
   public CameraAvailable: boolean;
 
   /**
+   * Indicates that state of teh camera is loaded.
+   */
+  public CameraStateLoaded: boolean;
+
+  /**
+   * The refresh interval for refreshing the data.
+   */
+  private refreshInterval: NodeJS.Timeout;
+
+  /**
    * Initializes a new instance of the StatusComponent class.
    * @param printerService The printer service.
    */
@@ -84,6 +94,7 @@ export class StatusComponent implements OnInit {
       this.BuildPlateTemp = temp.BuildPlateTemp.toString();
 
       this.CameraAvailable = await this.printerService.GetIsCameraEnabled();
+      this.CameraStateLoaded = true;
     }
     catch (e){
       ErrorLogger.NonFatalError(e);
@@ -96,7 +107,7 @@ export class StatusComponent implements OnInit {
   ngOnInit(): void {
     this.UpdateStatusText();
 
-    setInterval(() => {
+    this.refreshInterval = setInterval(() => {
       this.UpdateStatusText();
     }, 2000);
   }
@@ -106,5 +117,15 @@ export class StatusComponent implements OnInit {
    */
   public Disconnect(): void{
     this.printerService.Disconnect();
+  }
+
+  /**
+  * Invoked when the Angular component is destroyed.
+  */
+  ngOnDestroy(): void  {
+    if (this.refreshInterval) {
+      clearInterval(this.refreshInterval);
+      this.refreshInterval = null;
+    }
   }
 }


### PR DESCRIPTION
Fixes #20 

Fixes some performance issues on the status page:
1)	Stops the data refresh when the page is left, so we don’t accumulate leaks refreshes over time
2)	Correctly centre the status table so there is no visual jump when the camera changes state
3)	Hide the camera state so until it is known, so we don’t get a flicker of incorrect information.
