### PR TITLE
Rev Version Number For v1.2 Builds

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -3,8 +3,8 @@ trigger:
 
 variables:
   major: 1
-  minor: 1
-  revision: $[counter(variables['major'], 100)]
+  minor: 2
+  revision: $[counter(format('{0}.{1}', variables['major'], variables['minor']), 100)]
 
 name: $(major).$(minor).$(revision)
 


### PR DESCRIPTION
- Sets version number for 1.2 for current milestone
- Updates the counter to reset the build number to 100 for each minor version bump