### PR TITLE
Camera Link Does Not Show 

### DIFF
--- a/src/electronApp/angularApp/components/camera/camera.component.html
+++ b/src/electronApp/angularApp/components/camera/camera.component.html
@@ -1,7 +1,7 @@
 <div class="cameraContainer">
     <div *ngIf="CameraAvailable; then cameraAvailableBlock else cameraNotAvailableBlock"></div>
     <ng-template #cameraAvailableBlock>
-        <img class="cameraFeed" src={{StreamAddress}} />
+        <img (error)="cameraError()" class="cameraFeed" src={{StreamAddress}} />
     </ng-template>
     
     <ng-template #cameraNotAvailableBlock>

--- a/src/electronApp/angularApp/components/camera/camera.component.html
+++ b/src/electronApp/angularApp/components/camera/camera.component.html
@@ -5,7 +5,7 @@
     </ng-template>
     
     <ng-template #cameraNotAvailableBlock>
-        <p class="error">Lost connection to printer camera (<a target="_blank" href='https://github.com/andycb/AdventurerClientJS/wiki/Using-The-Printer-Camera'>Help</a>)</p>
+        <p class="error">Lost connection to printer camera (<a target="_blank" class="accentColor" href='https://github.com/andycb/AdventurerClientJS/wiki/Using-The-Printer-Camera'>Help</a>)</p>
         <a mat-stroked-button [routerLink]="'/status'">Printer Status</a> 
     </ng-template>    
 </div>

--- a/src/electronApp/angularApp/components/camera/camera.component.html
+++ b/src/electronApp/angularApp/components/camera/camera.component.html
@@ -1,7 +1,7 @@
 <div class="cameraContainer">
     <div *ngIf="CameraAvailable; then cameraAvailableBlock else cameraNotAvailableBlock"></div>
     <ng-template #cameraAvailableBlock>
-        <img (error)="cameraError()" class="cameraFeed" src={{StreamAddress}} />
+        <img class="cameraFeed" [src]="StreamAddress" />
     </ng-template>
     
     <ng-template #cameraNotAvailableBlock>

--- a/src/electronApp/angularApp/components/camera/camera.component.ts
+++ b/src/electronApp/angularApp/components/camera/camera.component.ts
@@ -1,6 +1,5 @@
-import { Component, OnInit } from '@angular/core';
+import { Component, OnInit, ViewChild, ElementRef } from '@angular/core';
 import { PrinterService } from '../../services/printerService';
-
 /**
  * Component for viewing the printer camera feed.
  */
@@ -26,6 +25,8 @@ export class CameraComponent implements OnInit {
    */
   private checkInterval: NodeJS.Timeout;
 
+  @ViewChild('ImageElement') private imageElement: ElementRef;
+
   /**
    * Initializes a new instance of the CameraComponent class.
    * @param printerService The printer service.
@@ -49,7 +50,11 @@ export class CameraComponent implements OnInit {
   * Invoked when the Angular component is destroyed.
   */
   ngOnDestroy(): void  {
-    this.StreamAddress = "";
+
+    // A bug in Chromium means that the img element will hold the connection to the
+    // mjpg stream forever, so call stop on the window to shut down all connections.
+    window.stop();
+
 
     if (this.checkInterval) {
       clearInterval(this.checkInterval);

--- a/src/electronApp/angularApp/components/camera/camera.component.ts
+++ b/src/electronApp/angularApp/components/camera/camera.component.ts
@@ -22,6 +22,11 @@ export class CameraComponent implements OnInit {
   public CameraAvailable: boolean = true;
 
   /**
+   * The check interval timeout for testing the camera connection.
+   */
+  private checkInterval: NodeJS.Timeout;
+
+  /**
    * Initializes a new instance of the CameraComponent class.
    * @param printerService The printer service.
    */
@@ -33,22 +38,22 @@ export class CameraComponent implements OnInit {
   * Invoked when the Angular component is initialized.
   */
   ngOnInit(): void {
-
+    // Depending on the printer settings, the camera may become unavailable when printing finished, 
+    // so set a timer to check for this and show a message if the camera is unavailable
+    this.checkInterval = setInterval(async () => {
+      this.CameraAvailable = await this.printerService.GetIsCameraEnabled();
+    }, 5000);
   }
 
   /**
   * Invoked when the Angular component is destroyed.
   */
   ngOnDestroy(): void  {
-    this.StreamAddress = null;
-  }
+    this.StreamAddress = "";
 
-  /**
-  * Invoked when the camera feed fails.
-  */
-  cameraError(): void {
-    // Depending on the printer settings, the camera may become unavailable when printing finished, 
-    // so show a message if the camera feed stops.
-    this.CameraAvailable = false;
+    if (this.checkInterval) {
+      clearInterval(this.checkInterval);
+      this.checkInterval = null;
+    }
   }
 }

--- a/src/electronApp/angularApp/components/camera/camera.component.ts
+++ b/src/electronApp/angularApp/components/camera/camera.component.ts
@@ -14,7 +14,7 @@ export class CameraComponent implements OnInit {
   /**
    * Gets the address of teh camera stream.
    */
-  public readonly StreamAddress: string;
+  public StreamAddress: string;
 
   /**
    * Gets a value indicating that teh camera is available.
@@ -40,7 +40,7 @@ export class CameraComponent implements OnInit {
   * Invoked when the Angular component is destroyed.
   */
   ngOnDestroy(): void  {
-
+    this.StreamAddress = null;
   }
 
   /**

--- a/src/electronApp/angularApp/components/camera/camera.component.ts
+++ b/src/electronApp/angularApp/components/camera/camera.component.ts
@@ -22,11 +22,6 @@ export class CameraComponent implements OnInit {
   public CameraAvailable: boolean = true;
 
   /**
-   * The check interval timeout for testing the camera connection.
-   */
-  private checkInterval: NodeJS.Timeout;
-
-  /**
    * Initializes a new instance of the CameraComponent class.
    * @param printerService The printer service.
    */
@@ -38,20 +33,22 @@ export class CameraComponent implements OnInit {
   * Invoked when the Angular component is initialized.
   */
   ngOnInit(): void {
-    // Depending on the printer settings, the camera may become unavailable when printing finished, 
-    // so set a timer to check for this and show a message if the camera is unavailable
-    this.checkInterval = setInterval(async () => {
-      this.CameraAvailable = await this.printerService.GetIsCameraEnabled();
-    }, 1000);
+
   }
 
   /**
   * Invoked when the Angular component is destroyed.
   */
   ngOnDestroy(): void  {
-    if (this.checkInterval) {
-      clearInterval(this.checkInterval);
-      this.checkInterval = null;
-    }
+
+  }
+
+  /**
+  * Invoked when the camera feed fails.
+  */
+  cameraError(): void {
+    // Depending on the printer settings, the camera may become unavailable when printing finished, 
+    // so show a message if the camera feed stops.
+    this.CameraAvailable = false;
   }
 }

--- a/src/electronApp/printerSdk/printerCamera.ts
+++ b/src/electronApp/printerSdk/printerCamera.ts
@@ -21,7 +21,7 @@ export class PrinterCamera {
     public IsEnabled(): Promise<boolean> {
         const checkCamera = (a) => {
             const request = new XMLHttpRequest();
-            request.timeout = 2000;
+            request.timeout = 3500;
             
             // Some printers only support streaming, so use the stream feed to check if the camera works
             // this means that we don't want to check for a full load, as the data is streaming and will never complete. 


### PR DESCRIPTION
Fixes #28 

With some printers it seems the camera streaming server is different and the request the app makes to the root webpage to verify the camera’s presence would stall indefinitely. This would cause the camera feed link to never show up.

This change adds a 2 second timeout to the camera test and switches to checking the stream connection which appears to be available on these printers.