### PR TITLE
Show Blocking dialog While Sending File. Lay Groundwork For Progress Bar

### DIFF
--- a/src/electronApp/angularApp/ directives/dragDropDirective.ts
+++ b/src/electronApp/angularApp/ directives/dragDropDirective.ts
@@ -47,6 +47,9 @@ export class DragDropDirective {
     evt.preventDefault();
     evt.stopPropagation();
 
+      // Remove CSS class from element
+      this.elementClass = '';
+
     const files = evt.dataTransfer.files;
     if (files.length > 0) {
       // If multiple files were dropped, use only the first

--- a/src/electronApp/angularApp/app.module.ts
+++ b/src/electronApp/angularApp/app.module.ts
@@ -16,6 +16,7 @@ import { DragDropDirective } from './ directives/dragDropDirective';
 import { CameraComponent } from './components/camera/camera.component';
 import { ConnectionErrorDialogComponent } from './components/connection-error-dialog/connection-error-dialog.component';
 import { StopPrintingConfirmationDialogComponent } from './components/stop-printing-confirmation-dialog/stop-printing-confirmation-dialog.component';
+import { TransferringDialogComponent } from './components/transferring-dialog/transferring-dialog.component';
 
 /**
  * The app module.
@@ -32,7 +33,8 @@ import { StopPrintingConfirmationDialogComponent } from './components/stop-print
     DragDropDirective,
     CameraComponent,
     ConnectionErrorDialogComponent,
-    StopPrintingConfirmationDialogComponent
+    StopPrintingConfirmationDialogComponent,
+    TransferringDialogComponent
   ],
   imports: [
     BrowserModule,

--- a/src/electronApp/angularApp/components/print/print.component.html
+++ b/src/electronApp/angularApp/components/print/print.component.html
@@ -1,21 +1,7 @@
-<ng-container
-  *ngIf="SendInProgress; then sending; else ready">
-</ng-container>
-
-<ng-template #ready>
-  <div #ready class="uploadFileContainer" (click)="fileInput.click()" appDragDrop (FileDropped)="uploadFile($event)">
-    <span *ngIf="ErrorMessage" class="error warningColor">{{ErrorMessage}}</span>
-    <span *ngIf="Success" class="success">File transferred successfully 🙂</span>
-      <span class="instructions drag">To print a .gx .gcode or .g file, drag it here or click to pick.</span>
-      <span class="instructions drop">Drop file here to print it.</span>
-      <input hidden type="file" #fileInput (change)="uploadFile($event.target.files)">
-    </div>
-</ng-template>
-
-<ng-template #sending>
-  <div #sending class="sendInProgress">
-    <mat-spinner diameter="50"></mat-spinner>
-    <br>
-    <span>Transferring file to printer</span>
-  </div>
-</ng-template>
+<div class="uploadFileContainer" (click)="fileInput.click()" appDragDrop (FileDropped)="uploadFile($event)">
+  <span *ngIf="ErrorMessage" class="error warningColor">{{ErrorMessage}}</span>
+  <span *ngIf="Success" class="success">File transferred successfully 🙂</span>
+    <span class="instructions drag">To print a .gx .gcode or .g file, drag it here or click to pick.</span>
+    <span class="instructions drop">Drop file here to print it.</span>
+    <input hidden type="file" #fileInput (change)="uploadFile($event.target.files)">
+</div>

--- a/src/electronApp/angularApp/components/print/print.component.ts
+++ b/src/electronApp/angularApp/components/print/print.component.ts
@@ -1,6 +1,8 @@
 import { Component, OnInit } from '@angular/core';
 import { PrinterService } from '../../services/printerService';
 import { ErrorLogger } from 'electronApp/core/errorLogger';
+import { MatDialog, MatDialogRef } from '@angular/material/dialog';
+import { TransferringDialogComponent } from "../transferring-dialog/transferring-dialog.component"
 
 /**
  * The Print component for sending files to the printer.
@@ -22,16 +24,21 @@ export class PrintComponent implements OnInit {
   public ErrorMessage: string;
 
   /**
-   * Gets a value indicating that a file transfer is in progress.
-   */
-  public SendInProgress = false;
-
-  /**
    * Gets a value indicating that a file transfer was successful.
    */
   public Success: boolean;
 
-  constructor(private printerService: PrinterService) {
+  /**
+   * Reference to the transferring dialog.
+   */
+  private dialogRef: MatDialogRef<TransferringDialogComponent> = null;
+
+  /**
+   * Initializes a new instance of the StatusComponent class.
+   * @param printerService Teh printer service.
+   * @param dialog A material dialog.
+   */
+  constructor(private printerService: PrinterService, private dialog: MatDialog) {
 
   }
 
@@ -42,31 +49,56 @@ export class PrintComponent implements OnInit {
   }
 
   /**
+  * Invoked when the Angular component is destroyed.
+  */
+ ngOnDestroy(): void {
+  if (this.dialogRef) {
+    this.dialogRef.close();
+  }
+}
+
+  /**
    * Sends a selected file to the printer/
    * @param event The HTML event args.
    */
-  public async uploadFile(event): Promise<void> {
+  public uploadFile(event): void {
     const path = event[0].path;
 
     if (path){
-      try{
-        this.SendInProgress = true;
-        this.Success = false;
-        this.ErrorMessage = null;
+      const startTime = new Date().getTime();
 
-        ErrorLogger.Trace("PrintComponent::uploadFile - Storing file");
-        await this.printerService.StoreFileAsync(path)
+      // Show a dialog
+      this.dialogRef = this.dialog.open(TransferringDialogComponent);
+      this.dialogRef.disableClose = true;
 
-        ErrorLogger.Trace("PrintComponent::uploadFile - Printing file");
-        await this.printerService.PrintFileAsync(event[0].name);
-        this.Success = true;
-      }
-      catch(e){
-        ErrorLogger.NonFatalError(e);
-        this.ErrorMessage = 'Failed to send file to printer.';
-      }
+      setImmediate(async () => {
+        try{ 
+          this.Success = false;
+          this.ErrorMessage = null;
+  
+          ErrorLogger.Trace("PrintComponent::uploadFile - Storing file");
+          await this.printerService.StoreFileAsync(path)
+  
+          ErrorLogger.Trace("PrintComponent::uploadFile - Printing file");
+          await this.printerService.PrintFileAsync(event[0].name);
+          this.Success = true;
+        }
+        catch(e){
+          ErrorLogger.NonFatalError(e);
+          this.ErrorMessage = 'Failed to send file to printer.';
+        }
+  
+        // Introduce a small delay so that with small files 
+        // the user gets to actually see the UI rather than a flicker
+        const endTime = new Date().getTime();
+        const duration = endTime - startTime;
+        const delay = Math.max(0, 800 - duration);
 
-      this.SendInProgress = false;
+        setTimeout(() => {
+          this.dialogRef.close();
+          this.dialogRef = null;
+        }, delay);
+      });
     }
   }
 }

--- a/src/electronApp/angularApp/components/stop-printing-confirmation-dialog/stop-printing-confirmation-dialog.component.html
+++ b/src/electronApp/angularApp/components/stop-printing-confirmation-dialog/stop-printing-confirmation-dialog.component.html
@@ -1,7 +1,7 @@
 <div class="StopPrintingConfirmationContainer">
     <h1 mat-dialog-title>Stop Printing</h1>
 
-    <div mat-dialog-content>Are you sure you want to stop printing.</div>
+    <div mat-dialog-content>Are you sure you want to stop printing?</div>
 
     <mat-dialog-actions align="end">
         <button (click)="Cancel()" mat-button mat-dialog-close>Cancel</button>

--- a/src/electronApp/angularApp/components/transferring-dialog/transferring-dialog.component.css
+++ b/src/electronApp/angularApp/components/transferring-dialog/transferring-dialog.component.css
@@ -1,0 +1,5 @@
+.sendInProgress {
+    display: flex;
+    align-items: center;
+    flex-direction: column;
+}

--- a/src/electronApp/angularApp/components/transferring-dialog/transferring-dialog.component.html
+++ b/src/electronApp/angularApp/components/transferring-dialog/transferring-dialog.component.html
@@ -1,0 +1,5 @@
+<div #sending class="sendInProgress">
+    <mat-spinner diameter="50"></mat-spinner>
+    <br>
+    <span>Please wait. Transferring file to printer.</span>
+  </div>

--- a/src/electronApp/angularApp/components/transferring-dialog/transferring-dialog.component.ts
+++ b/src/electronApp/angularApp/components/transferring-dialog/transferring-dialog.component.ts
@@ -1,0 +1,16 @@
+import { Component, OnInit, Inject, ChangeDetectorRef, ApplicationRef, ViewChild, ElementRef } from '@angular/core';
+
+@Component({
+  selector: 'app-transferring-dialog',
+  templateUrl: './transferring-dialog.component.html',
+  styleUrls: ['./transferring-dialog.component.css']
+})
+export class TransferringDialogComponent implements OnInit {
+
+  /**
+   * Invoked when the Angular component is initialized.
+   */
+  ngOnInit(): void {
+  }
+
+}

--- a/src/electronApp/angularApp/material/material.module.ts
+++ b/src/electronApp/angularApp/material/material.module.ts
@@ -10,6 +10,7 @@ import {MatProgressSpinnerModule} from '@angular/material/progress-spinner';
 import {MatTableModule} from '@angular/material/table'; 
 import {MatCheckboxModule} from '@angular/material/checkbox';
 import {MatDialogModule} from '@angular/material/dialog';
+import {MatProgressBarModule} from '@angular/material/progress-bar';
 
 /**
  * Modulus containing the requires Angular material modules.
@@ -26,6 +27,7 @@ import {MatDialogModule} from '@angular/material/dialog';
     MatFormFieldModule,
     MatInputModule,
     MatProgressSpinnerModule,
+    MatProgressBarModule,
     MatTableModule,
     MatCheckboxModule,
     MatDialogModule
@@ -38,6 +40,7 @@ import {MatDialogModule} from '@angular/material/dialog';
     MatFormFieldModule,
     MatInputModule,
     MatProgressSpinnerModule,
+    MatProgressBarModule,
     MatTableModule,
     MatCheckboxModule,
     MatDialogModule

--- a/src/electronApp/angularApp/services/iPrinterService.ts
+++ b/src/electronApp/angularApp/services/iPrinterService.ts
@@ -1,6 +1,6 @@
 import { PrinterStatus, FirmwareVersionResponse, TemperatureResponse, PrinterDebugMonitor } from '../../printerSdk/entities';
 import { PrinterCamera } from '../../printerSdk/printerCamera'
-import { EventDispatcher } from '../../core/eventDispatcher';
+import { EventDispatcher, PromiseWithProgress } from '../../core';
 
 /**
  * Interface fot the printer service.
@@ -77,7 +77,7 @@ export interface IPrinterService {
      * will be renamed to .g.
      * @param filePath The path of the file to transferer.
      */
-    StoreFileAsync(filePath: string): Promise<void>;
+    StoreFileAsync(filePath: string): PromiseWithProgress<void>;
 
     /**
      * Requests the firmware version info from the printer.

--- a/src/electronApp/angularApp/services/printerService.ts
+++ b/src/electronApp/angularApp/services/printerService.ts
@@ -1,10 +1,9 @@
 import { Injectable } from '@angular/core';
 import { IPrinterService } from './iPrinterService';
-import { PrinterStatus, TemperatureResponse, FirmwareVersionResponse, PrinterDebugMonitor } from '../../printerSdk/entities';
-import { EventDispatcher } from '../../core/eventDispatcher';
+import { PrinterStatus, TemperatureResponse, FirmwareVersionResponse, PrinterDebugMonitor,  } from '../../printerSdk/entities';
 import { Printer } from '../../printerSdk/printer';
-import { ErrorLogger } from '../../core/errorLogger';
 import { PrinterCamera } from '../../printerSdk/printerCamera'
+import { ErrorLogger, PromiseWithProgress, EventDispatcher } from '../../core';
 
 const path = window.require('path');
 
@@ -154,7 +153,7 @@ export class PrinterService implements IPrinterService {
     }
 
     /** @inheritdoc */
-    public StoreFileAsync(filePath: string): Promise<void> {
+    public StoreFileAsync(filePath: string): PromiseWithProgress<void>{ 
         if (this.printer == null) {
             throw new Error('Cannot call this method before calling and awaiting ConnectAsnc()');
         }

--- a/src/electronApp/core/PromiseWithProgress.ts
+++ b/src/electronApp/core/PromiseWithProgress.ts
@@ -1,0 +1,36 @@
+import { EventDispatcher } from './eventDispatcher';
+
+/**
+ * A wrapper around a promise, which also provides a progress update.
+ */
+export class PromiseWithProgress<T> {
+    /**
+     * The promise to the completion of the operation.
+     */
+    public readonly Promise: Promise<T>;
+
+    /**
+     * Event raised when there is an update to the progress.
+     */
+    public readonly Progress = new EventDispatcher<number>();
+
+    /**
+     * Initializes a new instance of the StatusComponent class.
+     * @param func The function to execute.
+     */
+    constructor (func: (updateProgress: (value: number) => void) => Promise<T>){
+        this.Promise = func((value: number) => this.UpdateProgress(value));
+    }
+
+    /**
+     * Updates the current progress.
+     * @param value 
+     */
+    private UpdateProgress(value: number): void{
+        if (value < 0 || value > 1){
+            throw new Error("Value is out of range");
+        }
+
+        this.Progress.Invoke(value);
+    }
+}

--- a/src/electronApp/core/index.ts
+++ b/src/electronApp/core/index.ts
@@ -1,0 +1,3 @@
+export * from './errorLogger';
+export * from './eventDispatcher';
+export * from './PromiseWithProgress';


### PR DESCRIPTION
Addresses #25 

This change adds a blocking dialog when a large file is being transferred to prevent the user from clicking on the app's navigation buttons.

The issue specifically asks for a progress bar to be added, this change adds the necessary reporting to add this, however as the file transfer currently takes place in the Electron renderer thread, there are issues where Angular is blocked from processing the updates util the transfer is finished. This should be resolved going forward by either moving the printer SDK into the Electron main process or using a web worker for the transfer. 

Both of these options require significant refactoring, so for this release (1.2) I'm opting to fix only the top level bug of sometimes the progress ring is not shown and sometimes is possible to interrupt the transfer by clicking away. I'll revisit the progress bar in a later release. 

![image](https://user-images.githubusercontent.com/4417762/107792282-da291680-6d4c-11eb-895a-3d4608a055e0.png)
