### PR TITLE
Fix some issues that came up during the QA pass.

### DIFF
--- a/src/electronApp/angularApp/components/about/about.component.html
+++ b/src/electronApp/angularApp/components/about/about.component.html
@@ -9,7 +9,7 @@
 
     <br>
     <br>
-    <span>Copyright (c) 2020 Andy Bradford</span>
+    <span>Copyright (c) 2020-2021 Andy Bradford</span>
 
     <br>
     <br>

--- a/src/electronApp/angularApp/components/print/print.component.ts
+++ b/src/electronApp/angularApp/components/print/print.component.ts
@@ -77,7 +77,7 @@ export class PrintComponent implements OnInit {
           this.ErrorMessage = null;
   
           ErrorLogger.Trace("PrintComponent::uploadFile - Storing file");
-          await this.printerService.StoreFileAsync(path)
+          await this.printerService.StoreFileAsync(path).Promise;
   
           ErrorLogger.Trace("PrintComponent::uploadFile - Printing file");
           await this.printerService.PrintFileAsync(event[0].name);

--- a/src/electronApp/angularApp/components/status/status.component.css
+++ b/src/electronApp/angularApp/components/status/status.component.css
@@ -17,6 +17,10 @@
 
 .button-row {
     display: flex;
-    align-items: center;
-    justify-content: space-around;
+    align-items: left;
+}
+
+.button-row button {
+    margin-right: 5px;
+    width: 36px;
 }

--- a/src/electronApp/angularApp/components/status/status.component.html
+++ b/src/electronApp/angularApp/components/status/status.component.html
@@ -63,23 +63,23 @@
 
     <tr>
         <th>Control</th>
-        <td>
+        <td class="controlButtons">
             <div class="button-row">
                 <div *ngIf="PrintStateLoaded">
                     <div *ngIf="PrintPaused; then printPausedBlock else printRunningBlock"></div>
                     <ng-template #printPausedBlock>
-                        <button disabled={{!IsPrinting}} mat-flat-button (click)="ResumePrinting()">
+                        <button disabled={{!IsPrinting}} (click)="ResumePrinting()">
                             <mat-icon aria-label="Resume Print">play_arrow</mat-icon>
                         </button>
                     </ng-template>
 
                     <ng-template #printRunningBlock>
-                        <button disabled={{!IsPrinting}} mat-flat-button (click)="PausePrinting()">
+                        <button disabled={{!IsPrinting}} mat-stroked-button (click)="PausePrinting()">
                             <mat-icon aria-label="Pause Print">pause</mat-icon>
                         </button>
                     </ng-template>
                 </div>
-                <button disabled={{!IsPrinting}} mat-flat-button (click)="OpenStopPrintingDialog()">
+                <button disabled={{!IsPrinting}} mat-stroked-button (click)="OpenStopPrintingDialog()">
                     <mat-icon aria-label="Stop Print">stop</mat-icon>
                 </button>
             </div>

--- a/src/electronApp/angularApp/components/status/status.component.ts
+++ b/src/electronApp/angularApp/components/status/status.component.ts
@@ -173,9 +173,9 @@ export class StatusComponent implements OnInit {
   /**
    * Pauses the printing.
    */
-  public PausePrinting(): void {
+  public async PausePrinting(): Promise<void> {
     try {
-      this.printerService.PausePrintingAsync();
+      await this.printerService.PausePrintingAsync();
     } catch (error) {
       ErrorLogger.NonFatalError(error);
     }
@@ -184,9 +184,9 @@ export class StatusComponent implements OnInit {
   /**
    * Resumes the printing.
    */
-  public ResumePrinting(): void {
+  public async ResumePrinting(): Promise<void> {
     try {
-      this.printerService.ResumePrintingAsync();
+      await this.printerService.ResumePrintingAsync();
     } catch (error) {
       ErrorLogger.NonFatalError(error);
     }

--- a/src/electronApp/angularApp/components/stop-printing-confirmation-dialog/stop-printing-confirmation-dialog.component.html
+++ b/src/electronApp/angularApp/components/stop-printing-confirmation-dialog/stop-printing-confirmation-dialog.component.html
@@ -4,7 +4,7 @@
     <div mat-dialog-content>Are you sure you want to stop printing?</div>
 
     <mat-dialog-actions align="end">
-        <button (click)="Cancel()" mat-button mat-dialog-close>Cancel</button>
-        <button (click)="StopPrintingAsync()" mat-button cdkFocusInitial>Stop Printing</button>
+        <button (click)="StopPrintingAsync()" mat-button>Stop Printing</button>
+        <button (click)="Cancel()" mat-button mat-dialog-close cdkFocusInitial>Cancel</button>
     </mat-dialog-actions>
 </div>

--- a/src/electronApp/angularApp/components/stop-printing-confirmation-dialog/stop-printing-confirmation-dialog.component.ts
+++ b/src/electronApp/angularApp/components/stop-printing-confirmation-dialog/stop-printing-confirmation-dialog.component.ts
@@ -32,10 +32,11 @@ export class StopPrintingConfirmationDialogComponent implements OnInit {
    */
   public async StopPrintingAsync(): Promise<any> {
     try {
-      this.printerService.StopPrintingAsync();
+      await this.printerService.StopPrintingAsync();
     } catch (error) {
       ErrorLogger.NonFatalError(error);
     }
+
     this.dialog.close();
   }
 

--- a/src/electronApp/printerSdk/printer.ts
+++ b/src/electronApp/printerSdk/printer.ts
@@ -7,6 +7,7 @@ import { PrinterCamera } from './printerCamera'
 import { PrinterStatus, FirmwareVersionResponse, TemperatureResponse, IPrinterResponse, PrinterDebugMonitor } from './entities';
 import { MachineCommands } from './machineCommands';
 import { PromiseWithProgress } from '../core/PromiseWithProgress'
+import { ErrorLogger } from 'electronApp/core';
 
 /**
  * Represents the printer.
@@ -258,6 +259,7 @@ export class Printer {
         });
 
         // Start a transfer
+        ErrorLogger.Trace("Starting file transfer");
         let message = '~' + MachineCommands.BeginWriteToSdCard + ' ' + modelBytes.length + ' 0:/user/' + fileName;
         this.SendToPrinter(message);
         await this.WaitForPrinterAck(MachineCommands.BeginWriteToSdCard);
@@ -295,7 +297,6 @@ export class Printer {
                 dataSize = actualLength;
             }
 
-
             // Always start each packet with four bytes
             const bufferToSend = Buffer.alloc(this.packetSizeBytes + 16);
             bufferToSend.writeUInt16LE(0x5a, 0);
@@ -327,6 +328,7 @@ export class Printer {
         this.SendToPrinter('');
 
         // Tell the printer that we have finished the file transfer
+        ErrorLogger.Trace("Ending file transfer");
         message = '~' + MachineCommands.EndWriteToSdCard;
 
         this.SendToPrinter(message);

--- a/src/electronApp/printerSdk/printerResponseReader.ts
+++ b/src/electronApp/printerSdk/printerResponseReader.ts
@@ -187,9 +187,11 @@ export class PrinterResponseReader
             case MachineCommands.BeginWriteToSdCard:
             case MachineCommands.EndWriteToSdCard:
             case MachineCommands.PrintFileFromSd:
+            case MachineCommands.StopPrinting:
+            case MachineCommands.PausePrinting:
                 return null;
             default:
-                throw new Error();
+                throw new Error("Unknown command cannot be mapped to a return value");
         }
     }
 }


### PR DESCRIPTION
Fixes a few issues identified during the QA pass for v1.2:

- **The copyright year is wrong**
The copyright  year was updated. Happy new year

- **The file would become corrupted during transfer transferred file was corrupted**
The status component was not currently awaiting the `PromiseWithProgress` and would sometimes try and print the file before it had finished sending.

- **The printer control buttons have low contrast in light mode** 
The flat material buttons don't work as well as the stroke buttons in light mode, so switched to stoke to match others in the app

- **The printer control buttons are not aligned with the disconnect button**
The buttons had a slight margin which was fixed.

- **Error shown in console after cancelling a print**
The response reader required the response type mapping for pause and cancel commands and was throwing an error. Mapped the return values and added a couple of missing awaits to ensure the error was observed.

- **The cancel print button should default to the safe option**
When cancelling a print, the yes button was the default focus, switch this to be the no button