### PR TITLE
Printer target temp

### DIFF
--- a/src/electronApp/angularApp/components/status/status.component.html
+++ b/src/electronApp/angularApp/components/status/status.component.html
@@ -36,12 +36,12 @@
 
     <tr>
         <th>Extruder temperature</th>
-        <td>{{Tool0Temp}}</td>
+        <td>{{Tool0Temp}}°C / {{Tool0TargetTemp}}°C</td>
     </tr>
 
     <tr>
         <th>Build plate temperature</th>
-        <td>{{BuildPlateTemp}}</td>
+        <td>{{BuildPlateTemp}}°C / {{BuildPlateTargetTemp}}°C</td>
     </tr>
 
     <tr>

--- a/src/electronApp/angularApp/components/status/status.component.ts
+++ b/src/electronApp/angularApp/components/status/status.component.ts
@@ -55,9 +55,19 @@ export class StatusComponent implements OnInit {
   public BuildPlateTemp: string;
 
   /**
+   * Gets the target temperature (un celsius) of the build plate.
+   */
+  public BuildPlateTargetTemp: string;
+
+  /**
    * Gets the temperature (un celsius) of the extruder.
    */
   public Tool0Temp: string;
+
+  /**
+   * Gets the target temperature (un celsius) of the extruder.
+   */
+  public Tool0TargetTemp: string;
 
   /**
    * Indicates that the printer camera is available.
@@ -106,7 +116,7 @@ export class StatusComponent implements OnInit {
       this.PrinterStatus = status.MachineStatus;
       this.MoveMode = status.MoveMode;
       this.Endstop = status.Endstop.X.toString() + ',' + status.Endstop.Y.toString() + ',' + status.Endstop.Z.toString();
-
+      
       ErrorLogger.Trace("StatsComponent::UpdateStatusText - Getting firmware Info");
       const firmwareInfo = await this.printerService.GetFirmwareVersionAsync();
       this.FirmwareVersion = firmwareInfo.FirmwareVersion;
@@ -120,6 +130,8 @@ export class StatusComponent implements OnInit {
       const temp = await this.printerService.GetTemperatureAsync();
       this.Tool0Temp = temp.Tool0Temp.toString();
       this.BuildPlateTemp = temp.BuildPlateTemp.toString();
+      this.Tool0TargetTemp = temp.Tool0TargetTemp.toString();
+      this.BuildPlateTargetTemp = temp.BuildPlateTargetTemp.toString();
 
       const cameraState = this.printerService.GetCamera().CameraState;
       this.CameraAvailable = cameraState == CameraState.Available;

--- a/src/electronApp/printerSdk/entities/temperatureResponse.ts
+++ b/src/electronApp/printerSdk/entities/temperatureResponse.ts
@@ -1,48 +1,59 @@
 
 import { IPrinterResponse } from './iPrinterResponse';
 
-export class TemperatureResponse implements IPrinterResponse
- {
-     /**
-      * Gets the temperature of tool 0;
-      */
-     public Tool0Temp: number;
+export class TemperatureResponse implements IPrinterResponse {
+    /**
+     * Gets the temperature of tool 0;
+     */
+    public Tool0Temp: number;
 
-     /**
-      * Gets the temperature of the build plate.
-      */
-     public BuildPlateTemp: number;
+    /**
+     * Gets the target temperature of tool 0;
+     */
+    public Tool0TargetTemp: number;
 
-     /**
-      * Initializes a new instance of the TemperatureResponse class.
-      */
-     constructor(responses: Array<string>)
-     {
-         // Example interaction:
-         // /
-         // CMD M105 Received.
-         // T0:25 /0 B:17/0
-         // ok
+    /**
+     * Gets the temperature of the build plate.
+     */
+    public BuildPlateTemp: number;
 
-         // Note the difference in spacing between the two slashes in the above. This is
-         // how is is sent from the printer.
-         responses.forEach(response => {
-             if (response.startsWith('T0:')){
-                 const parts = response.split(' ');
-                 parts.forEach(part => {
-                     const tempSplit = part.split(/\:(.+)/);
-                     for (let i = 0; i < tempSplit.length; ++i){
-                         if (tempSplit[i] === 'T0'){
-                             this.Tool0Temp = Number.parseFloat(tempSplit[i + 1]);
-                         }
-                         else if (tempSplit[i] === 'B'){
-                             let temp = tempSplit[i + 1];
-                             temp = temp.substr(0, temp.indexOf('/'));
-                             this.BuildPlateTemp = Number.parseFloat(temp);
-                         }
-                     }
-                 });
-             }
-         });
-     }
- }
+    /**
+     * Gets the target temperature of the build plate.
+     */
+    public BuildPlateTargetTemp: number;
+
+    /**
+     * Initializes a new instance of the TemperatureResponse class.
+     */
+    constructor(responses: Array<string>) {
+        // Example interaction:
+        // /
+        // CMD M105 Received.
+        // T0:25 /250 B:17/150
+        // ok
+
+        // Note the difference in spacing between the two slashes in the above. This is
+        // how is is sent from the printer.
+        responses.forEach(response => {
+            if (response.startsWith('T0:')) { // the T0:25 /250 B:17/150 part of the response
+                const parts = response.split(' '); // splits at space
+                parts.forEach(part => {
+                    const tempSplit = part.split(/\:(.+)/); // split part into it's components "T0", "{T0Temp}"" OR "/{T0TargetTemp}" OR "B", "{BuildPlateTemp}/{BuildPlateTargetTemp}"
+                    for (let i = 0; i < tempSplit.length; ++i) {
+                        if (tempSplit[i] === 'T0') { // if it's the T0 temp part (Tool0)
+                            this.Tool0Temp = Number.parseFloat(tempSplit[i + 1]); // put the T0Temp into Tool0Temp
+                        }
+                        else if (tempSplit[i].substring(0, 1) === '/') { // if the tempSplit starts with '/' ("/{T0TargetTemp}")
+                            this.Tool0TargetTemp = Number.parseFloat(tempSplit[i].substring(1)); // get whats after '/' into Tool0TargetTemp
+                        }
+                        else if (tempSplit[i] === 'B') { // if it's the B part (BuildPlate)
+                            let temp = tempSplit[i + 1];
+                            this.BuildPlateTemp = Number.parseFloat(temp.substr(0, temp.indexOf('/'))); // put what's before '/' into BuildPlateTemp
+                            this.BuildPlateTargetTemp = Number.parseFloat(temp.substr(temp.indexOf('/') + 1)); // put what's after '/' inti BuildPlateTargetTemp
+                        }
+                    }
+                });
+            }
+        });
+    }
+}

--- a/stubPrinter/stubPrinter.js
+++ b/stubPrinter/stubPrinter.js
@@ -1,84 +1,83 @@
 var net = require('net');
 
-var server = net.createServer((socket) => {    
+var server = net.createServer((socket) => {
     var isReceivingFile = false;
 
     socket.on('data', (data) => {
         var dataStr = data.toString();
         var lines = dataStr.split('\n');
 
-        for (var i = 0; i < lines.length; ++i){
-        var line = lines[i]; 
+        for (var i = 0; i < lines.length; ++i) {
+            var line = lines[i];
 
-        var parts = line.split(' ');
-    
-        var command = "";
-        if (parts.length > 0){
-            var commandPart = parts[0];
-            if (commandPart.startsWith("~")){
-                command = commandPart.substring(1, commandPart.length)
-            } 
-        }
+            var parts = line.split(' ');
 
-        var respond = function(text){
-            socket.write(text + "\n");
-        }
-
-        if (command != "") {
-            console.log("...." + command);
-            if (isReceivingFile && command == "M29"){
-                isReceivingFile = false;
-            }
-            else if (isReceivingFile) {
-                console.log("Ignored");
-                return;
+            var command = "";
+            if (parts.length > 0) {
+                var commandPart = parts[0];
+                if (commandPart.startsWith("~")) {
+                    command = commandPart.substring(1, commandPart.length)
+                }
             }
 
-            respond("CMD " + command + " Received.");
-            console.log(">" + data);
+            var respond = function(text) {
+                socket.write(text + "\n");
+            }
 
-            switch(command){
-                case "M119":
-                    respond("Endstop: X-max:1 Y-max:0 Z-max:0");
-                    respond("MachineStatus: READY");
-                    respond("MoveMode: READY");
-                    respond("Status: S:0 L:0 J:0 F:0");
-                    respond("ok");
-                    break;
-    
-                case "M115":
-                    respond("Machine Type: Test");
-                    respond("Machine Name: Testl");
-                    respond("Firmware: v1.0.0");
-                    respond("SN: XXXX999999");
-                    respond("X: 150 Y: 150 Z: 150");
-                    respond("Tool Count: 1");
-                    respond("ok");
-                    break;
+            if (command != "") {
+                console.log("...." + command);
+                if (isReceivingFile && command == "M29") {
+                    isReceivingFile = false;
+                } else if (isReceivingFile) {
+                    console.log("Ignored");
+                    return;
+                }
 
-                case "M105":
-                    var t1 = Math.floor(Math.random() * Math.floor(200));
-                    var t2 = Math.floor(Math.random() * Math.floor(100));
-                    respond("T0:" + t1 + " /0 B:" + t2 + "/0");
-                    respond("ok");
-                    break;
+                respond("CMD " + command + " Received.");
+                console.log(">" + data);
+
+                switch (command) {
+                    case "M119":
+                        respond("Endstop: X-max:1 Y-max:0 Z-max:0");
+                        respond("MachineStatus: READY");
+                        respond("MoveMode: READY");
+                        respond("Status: S:0 L:0 J:0 F:0");
+                        respond("ok");
+                        break;
+
+                    case "M115":
+                        respond("Machine Type: Test");
+                        respond("Machine Name: Testl");
+                        respond("Firmware: v1.0.0");
+                        respond("SN: XXXX999999");
+                        respond("X: 150 Y: 150 Z: 150");
+                        respond("Tool Count: 1");
+                        respond("ok");
+                        break;
+
+                    case "M105":
+                        var t1 = Math.floor(Math.random() * Math.floor(200));
+                        var t2 = Math.floor(Math.random() * Math.floor(100));
+                        respond("T0:" + t1 + " /" + (t1 + 15) + " B:" + t2 + "/" + (t2 + 10) + " ");
+                        respond("ok");
+                        break;
 
 
-                case "M29":
-                    startTime = new Date().getTime();
-                    while (new Date().getTime() < startTime + 6000);
-                    respond("ok");
-                    
-                    break;
+                    case "M29":
+                        startTime = new Date().getTime();
+                        while (new Date().getTime() < startTime + 6000);
+                        respond("ok");
 
-                case "M28":
-                    respond("ok");
-                    
-                    break;
+                        break;
 
-                default:
-                    respond("ok");
-                    break;
+                    case "M28":
+                        respond("ok");
+
+                        break;
+
+                    default:
+                        respond("ok");
+                        break;
                 }
             }
         }
@@ -86,4 +85,3 @@ var server = net.createServer((socket) => {
 });
 
 server.listen(8899, '127.0.0.1');
-


### PR DESCRIPTION
This would add the targeted temperature for both the bed and nozzle.
![Status page with printer target temp](https://user-images.githubusercontent.com/40121865/113303179-1ca8b180-9301-11eb-9250-73a84fd7fb1e.png)

Currently, the target temp displays 0°C if the printer isn't printing.
Should it maybe be hidden if nothing is being printed?
