### PR TITLE
Disable ContextIsolation in Electron 12

### DIFF
--- a/src/electronMain.ts
+++ b/src/electronMain.ts
@@ -9,6 +9,7 @@ function createWindow(): void {
     height: 560,
     webPreferences: {
       nodeIntegration: true,
+      contextIsolation: false,
       enableRemoteModule: true,
       preload: path.join(__dirname, '/preload.js'),
     },


### PR DESCRIPTION
As we use require in the renderer process, it is necessary to disable context isolation, which now defaults to true in Electron 12: https://www.electronjs.org/docs/breaking-changes