### PR TITLE
Run CI Builds with more recent NodeJS version

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -101,7 +101,7 @@ jobs:
     inputs:
       SourceFolder: 'src/distPackages'
       Contents: |
-        AdventurerClient-mac.dmg
+        AdventurerClient-macx64.dmg
       TargetFolder: 'drop'
       CleanTargetFolder: true
       preserveTimestamp: true

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -16,7 +16,7 @@ jobs:
   steps:
   - task: NodeTool@0
     inputs:
-      versionSpec: '10.x'
+      versionSpec: '16.x'
     displayName: 'Install Node.js'
 
   - script: |

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -76,7 +76,7 @@ jobs:
   steps:
   - task: NodeTool@0
     inputs:
-      versionSpec: '10.x'
+Update for       versionSpec: '16.x'
     displayName: 'Install Node.js'
 
   - script: |

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -76,7 +76,7 @@ jobs:
   steps:
   - task: NodeTool@0
     inputs:
-Update for       versionSpec: '16.x'
+      versionSpec: '16.x'
     displayName: 'Install Node.js'
 
   - script: |


### PR DESCRIPTION
CI builds are failing because the Azure Pipeline is installing an old Build of Node. Update the pipeline to use a more recent build.